### PR TITLE
Use mbstring functions instead of deprecated utf8 functions

### DIFF
--- a/pages/main.php
+++ b/pages/main.php
@@ -219,7 +219,7 @@
 		echo '<br />', $t_release_title, $t_scheduled_release_date, lang_get( 'word_separator' ), '<br />';
 
 		$t_release_title_without_hyperlinks = $t_project_name . ' - ' . $t_version_name . $t_scheduled_release_date;
-		echo utf8_str_pad( '', utf8_strlen( $t_release_title_without_hyperlinks ), '=' ), '<br />';
+		echo utf8_str_pad( '', mb_strlen( $t_release_title_without_hyperlinks ), '=' ), '<br />';
 	} /* End of print_version_header() */
 
 	/**


### PR DESCRIPTION
utf8 functions like utf8_strlen will be deprecated in MantisBT 2.13.0 [1]

The functions are still supported but will generate DEPRCECATED messages in PHP logs.
The functions are no longer needed as we made `mbstring` a mandatory PHP extension.

[1] https://mantisbt.org/bugs/view.php?id=23214