### PR TITLE
fix error when open plugin manager page

### DIFF
--- a/pages/api.php
+++ b/pages/api.php
@@ -1,5 +1,5 @@
 <?php
-	define('PLUGIN_WORKLOAD_LOGIN_HISTORY_FILE', 'plugins/workload/log/log_workload');
+	define('PLUGIN_WORKLOAD_LOGIN_HISTORY_FILE', 'plugins/Workload/log/log_workload');
 	define('PLUGIN_WORKLOAD_LOGIN_HISTORY_ENTRY_MAX', 5000);
 	
 	define('PLUGIN_WORKLOAD_VAR_IDX_NONE', '-1');


### PR DESCRIPTION
Hi.

I found the following error occurrs when opening the plug-in management page `${MANTISBT_URI}/manage_plugin_page.php`, with MantisBT environment installed the Workload plug-in according to the [Installation manual](https://github.com/mantisbt-plugins/workload/wiki/User-Guide#installation).

```
SYSTEM WARNING

'file(plugins/workload/log/log_workload): failed to open stream: No such file or directory' in '/var/www/html/plugins/Workload/pages/api.php' line 23

Please use the "Back" button in your web browser to return to the previous page. There you can correct whatever problems were identified in this error or select another action. You can also click an option from the menu bar to go directly to a new section.
```

The "PLUGIN_WORKLOAD_LOGIN_HISTORY_FILE" value in the "/Workload/pages/api.php" file was the cause, so I fixed it.

Reproduction environment:

* This container environemnt - https://hub.docker.com/r/vimagick/mantisbt/dockerfile
  * mantisbt v2.22.1
    * Workload plugin [a9474cd](https://github.com/mantisbt-plugins/workload/tree/a9474cde32fa7937cfab10908427e3b9c766587c)