### PR TITLE
Use single quotes for lang strings

### DIFF
--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -6,7 +6,7 @@
 	$s_plugin_workload_config = 'Configuration';
 	
 	#Plugin configuration
-	$s_plugin_workload_config_ana = "Analysis";
+	$s_plugin_workload_config_ana = 'Analysis';
 	$s_plugin_workload_status_level = 'Percentage of higher remaining work to warn about';
 	$s_plugin_workload_status_threshold = 'Issue status threshold to warn about higher remaining work';
 	$s_plugin_workload_progress_status_level = 'Percentage of lower progress to warn about';		


### PR DESCRIPTION
Fixes error during Test Lang check:

```
Checking language files for plugin Workload:
Testing English language file...
Testing language file 'strings_english.txt' (phase 1)...
ERROR: Language strings should be single-quoted (line 9)
```